### PR TITLE
feat: emotion 등록/조회/삭제 api 구현

### DIFF
--- a/BORA/line/serializers.py
+++ b/BORA/line/serializers.py
@@ -242,3 +242,8 @@ class NewAnswerSerializer(serializers.ModelSerializer):
         model=Answer
         fields=['ans_id','content','ans_que','ans_user']
 
+class NewEmoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model=Emotion
+        fields=['emo_id','content','emo_line','emo_postsec','emo_user']
+

--- a/BORA/line/urls.py
+++ b/BORA/line/urls.py
@@ -18,6 +18,5 @@ urlpatterns = [
         path('qna/<int:line_pk>/',LineQnAView.as_view()),
         path('qnadelete/<int:question_pk>/',DeleteQueView.as_view()),
         path('ans/<int:question_pk>/',AnswerView.as_view()),
-        # path('comcomdelete/<int:linecomcom_pk>/',DeleteComComView.as_view()),
-
+        path('emo/<int:line_pk>/',EmoView.as_view()),
 ]


### PR DESCRIPTION
## Solved Issue

close #29

<br>

## Motivation

- emotion 등록/조회/삭제 api 구현

<br>

## Key Changes

- 한 밑줄 클릭 시 모든 emotion조회
- emotion 등록/ 삭제 (pk:line_pk, response로 content)

<br>

## Result
- 밑줄 감정 등록

<img width="300" alt="스크린샷 2023-08-08 오전 11 52 04" src="https://github.com/BORA-team1/backend/assets/100216331/4770de4c-ed5c-403e-82c1-3810e72918e3">


- 밑줄 감정 조회

<img width="300" alt="스크린샷 2023-08-08 오전 11 52 39" src="https://github.com/BORA-team1/backend/assets/100216331/5d155719-b2c3-40cd-937c-94306cdcde8d">

- 밑줄 감정 삭제

<img width="300" alt="스크린샷 2023-08-08 오전 11 53 02" src="https://github.com/BORA-team1/backend/assets/100216331/6af39c85-b795-43ec-bd1e-1cc59a0cbb84">
