### PR TITLE
Feat: 위치정보로 밑줄의 콘텐츠 조회하는 api 추가

### DIFF
--- a/BORA/line/urls.py
+++ b/BORA/line/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
         path('qnadelete/<int:question_pk>/',DeleteQueView.as_view()),
         path('ans/<int:question_pk>/',AnswerView.as_view()),
         path('emo/<int:line_pk>/',EmoView.as_view()),
-        path('com/w/<int:post_pk>/',Com2View.as_view()),
-        path('qna/w/<int:post_pk>/',QnA2View.as_view()),
-        path('emo/w/<int:post_pk>/',Emo2View.as_view()),
+        path('com/w/<int:post_pk>/',LineCom2View.as_view()),
+        path('qna/w/<int:post_pk>/',LineQnA2View.as_view()),
+        path('emo/w/<int:post_pk>/',LineEmo2View.as_view()),
 ]

--- a/BORA/line/urls.py
+++ b/BORA/line/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
         path('qnadelete/<int:question_pk>/',DeleteQueView.as_view()),
         path('ans/<int:question_pk>/',AnswerView.as_view()),
         path('emo/<int:line_pk>/',EmoView.as_view()),
-        path('com/w/<int:post_pk>/',MyLineCom2View.as_view()),
-        
+        path('com/w/<int:post_pk>/',Com2View.as_view()),
+        path('qna/w/<int:post_pk>/',QnA2View.as_view()),
+        path('emo/w/<int:post_pk>/',Emo2View.as_view()),
 ]

--- a/BORA/line/urls.py
+++ b/BORA/line/urls.py
@@ -19,4 +19,6 @@ urlpatterns = [
         path('qnadelete/<int:question_pk>/',DeleteQueView.as_view()),
         path('ans/<int:question_pk>/',AnswerView.as_view()),
         path('emo/<int:line_pk>/',EmoView.as_view()),
+        path('com/w/<int:post_pk>/',MyLineCom2View.as_view()),
+        
 ]

--- a/BORA/line/views.py
+++ b/BORA/line/views.py
@@ -103,7 +103,7 @@ class LineComView(views.APIView):
         return Response({'message':'밑줄 댓글 등록 실패','error':serializer.errors},status=status.HTTP_400_BAD_REQUEST)
     
 
-class MyLineCom2View(views.APIView):
+class LineCom2View(views.APIView):
     permission_classes = [IsAuthenticated]
     def get(self, request, post_pk):
         postsec=request.data['line_postsec']
@@ -192,7 +192,7 @@ class LineQnAView(views.APIView):
         queseri=QuestionSerializer(ques,many=True,context={'request': request})
         return Response({"message": "밑줄 Q&A 조회 성공","data":{"line_id":line.line_id,"content":line.content,'Question':queseri.data}})
 
-class MyLineQnA2View(views.APIView):
+class LineQnA2View(views.APIView):
     def post(self, request, post_pk):
         postsec=get_object_or_404(PostSec, sec_id=request.data['line_postsec'])
         sentence=request.data['sentence']
@@ -244,7 +244,7 @@ class EmoView(views.APIView):
         content=request.data['content']
         postsec=line.line_postsec
         now_user=request.user
-        if Emotion.objects.filter(emo_line=line_pk,emo_user=now_user.id).exists() :
+        if Emotion.objects.filter(emo_line=line_pk,emo_user=now_user.id,content=content).exists() :
             return Response({"message": "이미 존재하는 감정표현입니다 "})
         emo=NewEmoSerializer(data={
             'content':content,
@@ -301,8 +301,103 @@ class EmoView(views.APIView):
 
         return Response({'message':"밑줄 감정표현 조회 성공","data":data})
     def delete(self, request,line_pk):
+        content=request.data['content']
         line=get_object_or_404(Line,line_id=line_pk)
         now_user=request.user
-        emo=Emotion.objects.filter(emo_line=line_pk,emo_user=now_user.id) 
+        emo=Emotion.objects.filter(emo_line=line_pk,emo_user=now_user.id,content=content) 
         emo.delete()
         return Response({"message": "밑줄 감정표현 삭제 성공"})
+    
+class LineEmo2View(views.APIView):
+    def post(self, request,post_pk):
+        postsec=get_object_or_404(PostSec, sec_id=request.data['line_postsec'])
+        sentence=request.data['sentence']
+        line_content=request.data['line_content']
+        content=request.data['content']
+        post= get_object_or_404(Post, post_id=post_pk)
+        now_user=request.user
+
+        line,created= Line.objects.get_or_create(sentence=sentence,line_post=post,line_postsec=postsec)
+        if created: 
+            line.content=line_content
+            line.save()
+
+        
+        if Emotion.objects.filter(emo_line=line.line_id,emo_user=now_user.id,content=content).exists() :
+            return Response({"message": "이미 존재하는 감정표현입니다 "})
+        emo=NewEmoSerializer(data={
+            'content':content,
+            'emo_line':line.line_id,
+            'emo_postsec':postsec.sec_id,
+            'emo_user':now_user.id
+        })
+        if emo.is_valid():
+            emo.save()
+            return Response({"message": "밑줄 감정표현 등록 성공!","data":emo.data})
+        else:
+            return Response({"message": "밑줄 감정표현 등록 실패!","error":emo.errors},status=status.HTTP_400_BAD_REQUEST)
+    def get (self, request,post_pk):
+        postsec=request.data['line_postsec']
+        sentence=request.data['sentence']
+        try:
+            line = Line.objects.get(line_post=post_pk, line_postsec=postsec, sentence=sentence)
+        except Line.DoesNotExist:
+            return Response({'message': '이 문장에 해당하는 감정표현이 없습니다!'}, status=status.HTTP_404_NOT_FOUND)
+
+        emos=Emotion.objects.filter(emo_line=line).all()  
+        is_my_1,is_my_2,is_my_3,is_my_4,is_my_5 =[False] * 5
+        
+        emo1s=emos.filter(content=1).all()
+        emo1count=emo1s.count()
+        for emo in emo1s:
+            if emo.emo_user==request.user : is_my_1=True
+
+        emo2s=emos.filter(content=2).all()
+        emo2count=emo2s.count()
+        for emo in emo2s:
+            if emo.emo_user==request.user : is_my_2=True
+        
+        emo3s=emos.filter(content=3).all()
+        emo3count=emo3s.count()
+        for emo in emo3s:
+            if emo.emo_user==request.user : is_my_3=True
+
+        emo4s=emos.filter(content=4).all()
+        emo4count=emo4s.count()
+        for emo in emo4s:
+            if emo.emo_user==request.user : is_my_4=True
+
+        emo5s=emos.filter(content=5).all()
+        emo5count=emo5s.count()
+        for emo in emo5s:
+            if emo.emo_user==request.user : is_my_5=True
+        
+        data = {
+                'line_id': line.line_id,
+                'content': line.content,
+                'Emotion': [
+                    {'content': 1, 'num': emo1count, 'is_my': is_my_1},
+                    {'content': 2, 'num': emo2count, 'is_my': is_my_2},
+                    {'content': 3, 'num': emo3count, 'is_my': is_my_3},
+                    {'content': 4, 'num': emo4count, 'is_my': is_my_4},
+                    {'content': 5, 'num': emo5count, 'is_my': is_my_5},
+                ],
+            }
+
+        return Response({'message':"밑줄 감정표현 조회 성공!","data":data})
+    def delete(self, request,post_pk):
+        postsec=request.data['line_postsec']
+        sentence=request.data['sentence']
+        content=request.data['content']
+
+        line = get_object_or_404(Line, line_post=post_pk, line_postsec=postsec, sentence=sentence)
+        
+        now_user=request.user
+        emo=Emotion.objects.filter(emo_line=line.line_id,emo_user=now_user.id,content=content) 
+        emo.delete()
+        return Response({"message": "밑줄 감정표현 삭제 성공!"})
+
+
+
+
+    


### PR DESCRIPTION
## Solved Issue

close #35

<br>

## Motivation

- line_id로 콘텐츠 불러오기가 어려워, 위치정보로 밑줄의 콘텐츠 조회하는 api 추가

<br>

## Key Changes

 - 밑줄 댓글 등록 w/ 위치정보
 - 밑줄 댓글 조회 w/ 위치정보
 - 밑줄 Q&A 등록 w/ 위치정보
 - 밑줄 Q&A 조회 w/ 위치정보
 - 밑줄 감정표현 등록 w/ 위치정보
 - 밑줄 감정표현 조회 w/ 위치정보
 -  밑줄 감정표현 삭제 w/ 위치정보

<br>

## Result
- 댓글
<img width="500" alt="스크린샷 2023-08-10 오전 1 23 24" src="https://github.com/BORA-team1/backend/assets/100216331/03951bbc-8d28-41a2-8d05-1936b69479a1">


- 질문
<img width="500" alt="스크린샷 2023-08-10 오전 1 24 55" src="https://github.com/BORA-team1/backend/assets/100216331/ac92fe90-490d-43b3-890b-d854e4153f15">


- 감정표현
<img width="500" alt="스크린샷 2023-08-10 오전 1 25 55" src="https://github.com/BORA-team1/backend/assets/100216331/5bd943b3-6da1-483f-8615-820620fa9a61">
